### PR TITLE
Fix typo in documentation

### DIFF
--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -10630,7 +10630,7 @@ xor({expr}, {expr})					*xor()*
 <
 
 							*feature-list*
-There are four types of features:
+There are three types of features:
 1.  Features that are only supported when they have been enabled when Vim
     was compiled |+feature-list|.  Example: >
 	:if has("cindent")


### PR DESCRIPTION
(or there is an item missing in the list following the typo)